### PR TITLE
Fixes togglePlay() unhandled exception in promise

### DIFF
--- a/js/moovie.js
+++ b/js/moovie.js
@@ -359,11 +359,11 @@ class Moovie {
         ** Change play/pause function and change all icons
         */
         var togglePlay = this.togglePlay = function togglePlay() {
-
+            let optionalPromise = null;
             // Remove poster background.
             document.getElementById("poster_layer_"+randomID).style.backgroundImage = "none";
             if (video.paused == true) {
-                video.play();
+                optionalPromise = video.play();
                 document.getElementById("moovie_bplay_"+randomID).src = icons.path+"pause.svg"
                 togglePoster("hide");
                 ChangeTooltip("play_button", 1);
@@ -373,7 +373,9 @@ class Moovie {
                 togglePoster("show");
                 ChangeTooltip("play_button", 0);
             }
+            return optionalPromise;
         }
+
 
         /*
         ** Fullscreen handler


### PR DESCRIPTION
Fixes the new autoplay restrictions where Play() can fail due to Chrome/Safari not registering a user interaction before the video plays (with sound). In this case, when a same-host iframe loads a call to video.play() is invoked to auto-start the video. If the user has been using the app then no problem the video autoplays fine. But if this user takes a link and sends it to one of their friends, who autoplays it when they load the link. In this scenario, chrome will actually block the video play and invoke an exception in a promise from video.play(). This promise is not correctly referenced and therefore the orphaned promise errors to the console instead of being handled.

The solution is to change togglePlay() such that the promise is returned to the caller, where the error condition can be gracefully handled.

This enables an attempt at autoplay, with a fallback behavior such as displaying a play.svg button.